### PR TITLE
Add Vundle to the Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 Vim syntax for [TOML](https://github.com/mojombo/toml). May be somewhat buggy -- it's my first attempt at a
 vim syntax file.
 
-This was developed the following revision:
+This was developed for the following TOML revision:
 [888ac9d5](https://github.com/mojombo/toml/commit/888ac9d56edd8182fed3cf33e6a3325cf9bd6b5d).
 
 ## Installation
 
-1. [Pathogen](https://github.com/tpope/vim-pathogen) or GTFO
-2. Clone/submodule into `$HOME/.vim/bundle/toml`, or wherever you've pointed your pathogen.
+## Pathogen
+
+Set up [Pathogen](https://github.com/tpope/vim-pathogen) then clone/submodule this repo into `~/.vim/bundle/toml`, or wherever you've pointed your Pathogen.
+
+## Vundle
+
+Set up [Vundle](https://github.com/gmarik/Vundle.vim) then add `Bundle 'cespare/vim-toml'` to your vimrc and run `:BundleInstall` from a fresh vim.


### PR DESCRIPTION
I've clarified that this repo also works with Vundle, and removed "Pathogen or GTFO".
