### PR TITLE
Add commentstring for vim-commentary.

### DIFF
--- a/ftplugin/toml.vim
+++ b/ftplugin/toml.vim
@@ -11,6 +11,8 @@ let b:did_ftplugin = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
+setlocal commentstring=#\ %s
+
 " Add NERDCommenter delimiters
 
 let s:delims = { 'left': '#' }


### PR DESCRIPTION
The [vim-commentary](https://github.com/tpope/vim-commentary) plugin looks for `commentstring` to define the `#` character.