### PR TITLE
Detect .cargo/config at the end of any path

### DIFF
--- a/ftdetect/toml.vim
+++ b/ftdetect/toml.vim
@@ -1,2 +1,2 @@
 " Rust uses several TOML config files that are not named with .toml.
-autocmd BufNewFile,BufRead *.toml,Cargo.lock,.cargo/config set filetype=toml
+autocmd BufNewFile,BufRead *.toml,Cargo.lock,*/.cargo/config set filetype=toml


### PR DESCRIPTION
By the [autocmd-patterns rules][1], the current `.cargo/config` pattern only matches `.cargo/config` as a literal argument.  This means that `vim config` (from inside `.cargo`) and `vim ~/.cargo/config` do not
match.  This seems sub-optimal.  This PR adds a wildcard to the front of the pattern so that any full path ending in `.cargo/config` is matched.

I hope you find it useful,
Kevin

[1]: http://vimdoc.sourceforge.net/htmldoc/autocmd.html#autocmd-patterns