### PR TITLE
Fix highlighting of tricky identifiers

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -39,10 +39,16 @@ hi def link tomlBoolean Boolean
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}T\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)/ display
 hi def link tomlDate Constant
 
-syn match tomlTable /^\s*\[[^#\[\]]\+\]\s*\(#.*\)\?$/ contains=tomlComment
+syn region tomlKeyDq oneline start=/"/ end=/"/ contains=tomlEscape contained
+hi def link tomlKeyDq Identifier
+
+syn region tomlKeySq oneline start=/'/ end=/'/ contained
+hi def link tomlKeySq Identifier
+
+syn region tomlTable oneline start=/^\s*\[[^\[]/ end=/\]/ contains=tomlKeyDq,tomlKeySq
 hi def link tomlTable Identifier
 
-syn match tomlTableArray /^\s*\[\[[^#\[\]]\+\]\]\s*\(#.*\)\?$/ contains=tomlComment
+syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKeyDq,tomlKeySq
 hi def link tomlTableArray Identifier
 
 syn keyword tomlTodo TODO FIXME XXX BUG contained


### PR DESCRIPTION
Stuff like ```[network.channel."#channelname"]``` wasn't highlighted properly, so I fixed that.