### PR TITLE
Highlight all valid date formats

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -36,7 +36,9 @@ syn match tomlBoolean /\<\%(true\|false\)\>/ display
 hi def link tomlBoolean Boolean
 
 " https://tools.ietf.org/html/rfc3339
-syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}T\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)/ display
+syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}/ display
+syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
+syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 hi def link tomlDate Constant
 
 syn region tomlKeyDq oneline start=/"/ end=/"/ contains=tomlEscape contained


### PR DESCRIPTION
Currently, the only date format that will get highlighting is the full format including both date and time portions and an offset. However, TOML permits leaving out some of these:

- The offset may be left out, indicating a "local" datetime with implementation-specific handling.
- Only the date portion may be included, specifying an entire day without precise time or offset.
- Only the time portion may be included, without a date or offset.
- In formats including both date and time, the 'T' may be replaced by a space.

This PR adds syntax highlighting for these other cases, which should now cover all ways to format a date or time permitted by the TOML specification.

Note that portions of invalid datetimes may now also get highlighting with this. For example, this will highlight the initial part of something like `2017-12-10T16:02:51.Z`, which is invalid because the fractional part is empty. The syntax script will recognize the initial part as a datetime without offset, so this will get highlighting. That may not be ideal, but I chose to keep it that way because otherwise the individual numbers would still get highlighting anyway, even though these wouldn't be valid TOML in this context. So in the end, it's basically the same kind of problem.

I hacked this together in a couple of minutes, so if you find any problems with this, please let me know. :grin: