### PR TITLE
Fix not to force overwriting undo_ftplugin

### DIFF
--- a/ftplugin/toml.vim
+++ b/ftplugin/toml.vim
@@ -29,8 +29,6 @@ else
 endif
 unlet s:delims
 
-let b:undo_ftplugin = ""
-
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
Fixed unnecessary overwrite by ftplugin. This meddled with other plugins as follows:

1. vim-toml initializes `b:undo_ftplugin` with an empty string
2. A plugin that appends a command to `b:undo_ftplugin` will insert ` | ` at the beginning of the string
3. The command will fail when it executes because it begins with ` | ` (invalid)

This variable should not be defined unless undo is required.

Cheers!