### PR TITLE
Update for Pipfile

### DIFF
--- a/ftdetect/toml.vim
+++ b/ftdetect/toml.vim
@@ -1,2 +1,2 @@
 " Go dep and Rust use several TOML config files that are not named with .toml.
-autocmd BufNewFile,BufRead *.toml,Gopkg.lock,Cargo.lock,*/.cargo/config set filetype=toml
+autocmd BufNewFile,BufRead *.toml,Gopkg.lock,Cargo.lock,*/.cargo/config,Pipfile set filetype=toml


### PR DESCRIPTION
[`Pipfiles`](https://github.com/pypa/pipfile#the-concept), used by [`pipenv`](https://github.com/pypa/pipenv) are TOML syntax. Would be helpful to have this plugin catch those files as well.