### PR TITLE
Proper keys highlighting

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -41,16 +41,19 @@ syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 hi def link tomlDate Constant
 
-syn region tomlKeyDq oneline start=/"/ end=/"/ contains=tomlEscape contained
+syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]_-]+\ze\s*\=/ display
+hi def link tomlKey Identifier
+
+syn region tomlKeyDq oneline start=/\v(^|[{,])\s*\zs"/ end=/"\ze\s*=/ contains=tomlEscape
 hi def link tomlKeyDq Identifier
 
-syn region tomlKeySq oneline start=/'/ end=/'/ contained
+syn region tomlKeySq oneline start=/\v(^|[{,])\s*\zs'/ end=/'\ze\s*=/
 hi def link tomlKeySq Identifier
 
-syn region tomlTable oneline start=/^\s*\[[^\[]/ end=/\]/ contains=tomlKeyDq,tomlKeySq
+syn region tomlTable oneline start=/^\s*\[[^\[]/ end=/\]/ contains=tomlKey,tomlKeyDq,tomlKeySq
 hi def link tomlTable Identifier
 
-syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKeyDq,tomlKeySq
+syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKey,tomlKeyDq,tomlKeySq
 hi def link tomlTableArray Identifier
 
 syn keyword tomlTodo TODO FIXME XXX BUG contained


### PR DESCRIPTION
Unquoted (bare) keys can only contains ASCII alphanumerics, underscores and dashes `[[:alphanum:]_-]`
Keys must be followed by an equal sign `=`
Keys may be found in inline tables
Quoted keys can include escaped quotes