### PR TITLE
Fix numbers

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -25,7 +25,8 @@ syn region tomlString oneline start=/'/ end=/'/
 syn region tomlString start=/'''/ end=/'''/
 hi def link tomlString String
 
-syn match tomlInteger /[+-]\=\<\d\(_\=\d\)*\>/ display
+syn match tomlInteger /[+-]\=\<[1-9]\(_\=\d\)*\>/ display
+syn match tomlInteger /[+-]\=\<0\>/ display
 syn match tomlInteger /[+-]\=\<0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*\>/ display
 syn match tomlInteger /[+-]\=\<0o[0-7]\(_\=[0-7]\)*\>/ display
 syn match tomlInteger /[+-]\=\<0b[01]\(_\=[01]\)*\>/ display

--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -25,15 +25,15 @@ syn region tomlString oneline start=/'/ end=/'/
 syn region tomlString start=/'''/ end=/'''/
 hi def link tomlString String
 
-syn match tomlInteger /[+-]\=\<[0-9]\(_\=\d\)*\>/ display
+syn match tomlInteger /[+-]\=\<\d\(_\=\d\)*\>/ display
 syn match tomlInteger /[+-]\=\<0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*\>/ display
 syn match tomlInteger /[+-]\=\<0o[0-7]\(_\=[0-7]\)*\>/ display
 syn match tomlInteger /[+-]\=\<0b[01]\(_\=[01]\)*\>/ display
 syn match tomlInteger /[+-]\=\<\(inf\|nan\)\>/ display
 hi def link tomlInteger Number
 
-syn match tomlFloat /[+-]\=\<[0-9]\(_\=\d\)*\.\d\+\>/ display
-syn match tomlFloat /[+-]\=\<[0-9]\(_\=\d\)*\(\.[0-9]\(_\=\d\)*\)\=[eE][+-]\=[0-9]\(_\=\d\)*\>/ display
+syn match tomlFloat /[+-]\=\<\d\(_\=\d\)*\.\d\+\>/ display
+syn match tomlFloat /[+-]\=\<\d\(_\=\d\)*\(\.\d\(_\=\d\)*\)\=[eE][+-]\=\d\(_\=\d\)*\>/ display
 hi def link tomlFloat Float
 
 syn match tomlBoolean /\<\%(true\|false\)\>/ display

--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -25,15 +25,15 @@ syn region tomlString oneline start=/'/ end=/'/
 syn region tomlString start=/'''/ end=/'''/
 hi def link tomlString String
 
-syn match tomlInteger /\<[+-]\=[0-9]\(_\=\d\)*\>/ display
-syn match tomlInteger /\<[+-]\=0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*\>/ display
-syn match tomlInteger /\<[+-]\=0o[0-7]\(_\=[0-7]\)*\>/ display
-syn match tomlInteger /\<[+-]\=0b[01]\(_\=[01]\)*\>/ display
-syn match tomlInteger /\<[+-]\=\(inf\|nan\)\>/ display
+syn match tomlInteger /[+-]\=\<[0-9]\(_\=\d\)*\>/ display
+syn match tomlInteger /[+-]\=\<0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*\>/ display
+syn match tomlInteger /[+-]\=\<0o[0-7]\(_\=[0-7]\)*\>/ display
+syn match tomlInteger /[+-]\=\<0b[01]\(_\=[01]\)*\>/ display
+syn match tomlInteger /[+-]\=\<\(inf\|nan\)\>/ display
 hi def link tomlInteger Number
 
-syn match tomlFloat /\<[+-]\=[0-9]\(_\=\d\)*\.\d\+\>/ display
-syn match tomlFloat /\<[+-]\=[0-9]\(_\=\d\)*\(\.[0-9]\(_\=\d\)*\)\=[eE][+-]\=[0-9]\(_\=\d\)*\>/ display
+syn match tomlFloat /[+-]\=\<[0-9]\(_\=\d\)*\.\d\+\>/ display
+syn match tomlFloat /[+-]\=\<[0-9]\(_\=\d\)*\(\.[0-9]\(_\=\d\)*\)\=[eE][+-]\=[0-9]\(_\=\d\)*\>/ display
 hi def link tomlFloat Float
 
 syn match tomlBoolean /\<\%(true\|false\)\>/ display


### PR DESCRIPTION
I found in some cases highlights are not correct:

- `+` and `-` before numbers are not highlighted since between space ' ' and sign '+'/'-' is not a word boundary.
- An integer starts with `0` (e.g. `042`) other than `0` is invalid (written in spec https://github.com/toml-lang/toml#integer )

I took screenshot before/after this PR.

Before:

<img width="703" alt="before" src="https://user-images.githubusercontent.com/823277/45952553-59193980-c042-11e8-9740-fb15731d8628.png">

After:

<img width="703" alt="after" src="https://user-images.githubusercontent.com/823277/45952572-61717480-c042-11e8-8f86-d505a548abf5.png">
