### PR TITLE
Change table highlighting

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -56,10 +56,10 @@ syn region tomlKeySq oneline start=/\v(^|[{,])\s*\zs'/ end=/'\ze\s*=/
 hi def link tomlKeySq Identifier
 
 syn region tomlTable oneline start=/^\s*\[[^\[]/ end=/\]/ contains=tomlKey,tomlKeyDq,tomlKeySq
-hi def link tomlTable Identifier
+hi def link tomlTable Title
 
 syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKey,tomlKeyDq,tomlKeySq
-hi def link tomlTableArray Identifier
+hi def link tomlTableArray Title
 
 syn keyword tomlTodo TODO FIXME XXX BUG contained
 hi def link tomlTodo Todo


### PR DESCRIPTION
Use a separate syntax group for table names. That makes tables to be highlighted separately from the variables.

Before the changes vim renders my toml file:
![image](https://user-images.githubusercontent.com/1213442/46493670-ab641280-c819-11e8-9f94-fb159bfa9786.png)

after:
![image](https://user-images.githubusercontent.com/1213442/46493570-6213c300-c819-11e8-80b4-2125d52c3657.png)
