### PR TITLE
Add support for dotted keys.

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -46,7 +46,7 @@ syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 hi def link tomlDate Constant
 
-syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]_-]+\ze\s*\=/ display
+syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]._-]+\ze\s*\=/ display
 hi def link tomlKey Identifier
 
 syn region tomlKeyDq oneline start=/\v(^|[{,])\s*\zs"/ end=/"\ze\s*=/ contains=tomlEscape


### PR DESCRIPTION
From the [TOML spec](https://github.com/toml-lang/toml/blob/v0.5.0/README.md):

> Dotted keys are a sequence of bare or quoted keys joined with a dot.  This allows for grouping similar properties together:
>
>     name = "Orange"
>     physical.color = "orange"
>     physical.shape = "round"
>     site."google.com" = true