### PR TITLE
(1) Add possibility to undo ftplugin and (2) only run NERDcommenter specific options when it is loaded

### DIFF
--- a/ftplugin/toml.vim
+++ b/ftplugin/toml.vim
@@ -10,9 +10,10 @@ let b:did_ftplugin = 1
 
 let s:save_cpo = &cpo
 set cpo&vim
-let b:undo_ftplugin = 'setlocal commentstring<'
+let b:undo_ftplugin = 'setlocal commentstring< comments<'
 
 setlocal commentstring=#\ %s
+setlocal comments=:#
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/ftplugin/toml.vim
+++ b/ftplugin/toml.vim
@@ -1,7 +1,7 @@
 " File: ftplugin/toml.vim
 " Author: Kevin Ballard <kevin@sb.org>
 " Description: FileType Plugin for Toml
-" Last Change: Dec 09, 2014
+" Last Change: Jan 19, 2019
 
 if exists('b:did_ftplugin')
     finish
@@ -10,6 +10,7 @@ let b:did_ftplugin = 1
 
 let s:save_cpo = &cpo
 set cpo&vim
+let b:undo_ftplugin = 'setlocal commentstring<'
 
 setlocal commentstring=#\ %s
 

--- a/ftplugin/toml.vim
+++ b/ftplugin/toml.vim
@@ -1,7 +1,7 @@
 " File: ftplugin/toml.vim
 " Author: Kevin Ballard <kevin@sb.org>
 " Description: FileType Plugin for Toml
-" Last Change: Jan 19, 2019
+" Last Change: Feb 12, 2019
 
 if exists('b:did_ftplugin')
     finish
@@ -13,22 +13,6 @@ set cpo&vim
 let b:undo_ftplugin = 'setlocal commentstring<'
 
 setlocal commentstring=#\ %s
-
-" Add NERDCommenter delimiters
-
-let s:delims = { 'left': '#' }
-if exists('g:NERDDelimiterMap')
-    if !has_key(g:NERDDelimiterMap, 'toml')
-        let g:NERDDelimiterMap.toml = s:delims
-    endif
-elseif exists('g:NERDCustomDelimiters')
-    if !has_key(g:NERDCustomDelimiters, 'toml')
-        let g:NERDCustomDelimiters.toml = s:delims
-    endif
-else
-    let g:NERDCustomDelimiters = { 'toml': s:delims }
-endif
-unlet s:delims
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
1. This lets people change filetypes within the window
    with `setfiletype`. Also update the last changed date.
2. This is a convention used in the vim runtime files so that people who
    don't use those specific plugins don't have their namespace polluted.