### PR TITLE
Use `setfiletype` in ftdetect/toml.vim to avoid loading twice.

### DIFF
--- a/ftdetect/toml.vim
+++ b/ftdetect/toml.vim
@@ -1,2 +1,2 @@
 " Go dep and Rust use several TOML config files that are not named with .toml.
-autocmd BufNewFile,BufRead *.toml,Gopkg.lock,Cargo.lock,*/.cargo/config,*/.cargo/credentials,Pipfile set filetype=toml
+autocmd BufNewFile,BufRead *.toml,Gopkg.lock,Cargo.lock,*/.cargo/config,*/.cargo/credentials,Pipfile setf toml


### PR DESCRIPTION
This is the recommended way to do ftdetect.
Here is an example: https://github.com/vim/vim/blob/1f20daa1d784e2d8ae13db5b9c8abbb648dd2a03/runtime/filetype.vim#L1491