### PR TITLE
Slightly changed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Set up [Vundle](https://github.com/VundleVim/Vundle.vim) then add `Plugin
 
 Set up [vim-plug](https://github.com/junegunn/vim-plug). In your .vimrc, between
 the lines for `call plug#begin()` and `call plug#end()`, add the line `Plug
-'cespare/vim-toml'`. Save `:w` and source `so%` your .vimrc and then then run `:PlugInstall`.
+'cespare/vim-toml'`. Reload your .vimrc and then run `:PlugInstall`.
 
 ### Janus
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Set up [Vundle](https://github.com/VundleVim/Vundle.vim) then add `Plugin
 
 Set up [vim-plug](https://github.com/junegunn/vim-plug). In your .vimrc, between
 the lines for `call plug#begin()` and `call plug#end()`, add the line `Plug
-'cespare/vim-toml'`. Then run `:PlugInstall` from a fresh vim instance.
+'cespare/vim-toml'`. Save `:w` and source `so%` your .vimrc and then then run `:PlugInstall`.
 
 ### Janus
 


### PR DESCRIPTION
Hi, I've made a minor suggestion concerning installation instructions for vim-plug. There is no need to re-start vim if the one wishes to source the modified .vimrc, which IMHO, is a faster and more natural way of adding new plugins.