### PR TITLE
don't highlight nested arrays as table titles

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -61,6 +61,10 @@ hi def link tomlTable Title
 syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKey,tomlKeyDq,tomlKeySq
 hi def link tomlTableArray Title
 
+syn cluster tomlValue contains=tomlArray,tomlString,tomlInteger,tomlFloat,tomlBoolean,tomlDate,tomlComment
+syn region tomlKeyValueArray start=/=\s*\[\zs/ end=/\]/ contains=@tomlValue
+syn region tomlArray start=/\[/ end=/\]/ contains=@tomlValue contained
+
 syn keyword tomlTodo TODO FIXME XXX BUG contained
 hi def link tomlTodo Todo
 


### PR DESCRIPTION
e.g. given the following

```toml
nested_array = [
  ["a", "b"],
  ["c", "d"],
]
```

The nested part was highlighted as table titles.