### PR TITLE
Support user-defined $CARGO_HOME directory

### DIFF
--- a/ftdetect/toml.vim
+++ b/ftdetect/toml.vim
@@ -1,2 +1,7 @@
 " Go dep and Rust use several TOML config files that are not named with .toml.
 autocmd BufNewFile,BufRead *.toml,Gopkg.lock,Cargo.lock,*/.cargo/config,*/.cargo/credentials,Pipfile setf toml
+
+" Support user-defined $CARGO_HOME directory
+if !empty($CARGO_HOME)
+    autocmd BufNewFile,BufRead $CARGO_HOME/config,$CARGO_HOME/credentials setf toml
+endif


### PR DESCRIPTION
Cargo allows users to change its data directory by means of the [`$CARGO_HOME`](https://doc.rust-lang.org/cargo/guide/cargo-home.html) environment variable. I have that variable set to `$XDG_DATA_HOME/cargo` which doesn't match any of the patterns specified by the plugin.
This patch adds support for a custom `$CARGO_HOME` directory.

I'm a vim newbie so my knowledge of vimscript is fairly limited. If there's a better/clearer way of doing this, I'm not aware of it. I'm sorry, if that's the case :)

Thank you for your work on the plugin!