### PR TITLE
Fix vint warnings about double-quotes

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -3,7 +3,7 @@
 " URL:        https://github.com/cespare/vim-toml
 " LICENSE:    MIT
 
-if exists("b:current_syntax")
+if exists('b:current_syntax')
   finish
 endif
 
@@ -73,4 +73,4 @@ hi def link tomlComment Comment
 
 syn sync minlines=500
 
-let b:current_syntax = "toml"
+let b:current_syntax = 'toml'


### PR DESCRIPTION
I was getting a couple of [vint](https://github.com/Vimjas/vint) warnings about double quotes while making changes for #52. This seems totally inconsequential, but if merged might keep other contributor's Syntastic installs happy :smile: 