### PR TITLE
Delimiter Highlighting

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -7,7 +7,7 @@ if exists('b:current_syntax')
   finish
 endif
 
-syn match tomlNoise /,/ display nextgroup=tomlInlineKey,@tomlValue skipempty skipwhite
+syn match tomlNoise /[,\.]/ display nextgroup=tomlInlineKey,@tomlValue skipempty skipwhite
 hi def link tomlNoise Delimiter
 
 syn match tomlOperator "=" display nextgroup=@tomlValue skipempty skipwhite
@@ -52,18 +52,18 @@ syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 hi def link tomlDate Constant
 
-syn match tomlKey /\v[a-z_\-]+(\.[a-z_\-]+)*(\s*\=)@=/ display
+syn match tomlKey /\v[a-z_\-]+(\.[a-z_\-]+)*(\s*\=)@=/ contains=tomlNoise display
 hi def link tomlKey Identifier
 
-syn region tomlKeyDq oneline start=/\v(^|[{,])\s*\zs"/ end=/"\ze\s*=/ contains=tomlEscape
+syn region tomlKeyDq oneline start=/\v(^|[{,])\s*\zs"/ end=/"\ze\s*=/ contains=tomlEscape,tomlNoise
 hi def link tomlKeyDq tomlKey
 
-syn region tomlKeySq oneline start=/\v(^|[{,])\s*\zs'/ end=/'\ze\s*=/
+syn region tomlKeySq oneline start=/\v(^|[{,])\s*\zs'/ end=/'\ze\s*=/ contains=tomlNoise
 hi def link tomlKeySq tomlKey
 
 syn cluster tomlTableKeys contains=tomlKey,tomlKeyDq,tomlKeySq
 
-syn match tomlTable /\v(^\s*\[?\s*)@<=\[[a-z_\-]+(\.[a-z_\-]+)*\](\s*\]?\s*$)@=/ contains=@tomlKeys display
+syn match tomlTable /\v(^\s*\[?\s*)@<=\[[a-z_\-]+(\.[a-z_\-]+)*\](\s*\]?\s*$)@=/ contains=tomlNoise,@tomlKeys display
 hi def link tomlTable Title
 
 syn region tomlTableInline matchgroup=tomlTable start="\V{" end="\V}" contains=ALLBUT,tomlTable transparent

--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -7,6 +7,12 @@ if exists('b:current_syntax')
   finish
 endif
 
+syn match tomlNoise /,/ display nextgroup=tomlInlineKey,@tomlValue skipempty skipwhite
+hi def link tomlNoise Delimiter
+
+syn match tomlOperator "=" display nextgroup=@tomlValue skipempty skipwhite
+hi def link tomlOperator Operator
+
 syn match tomlEscape /\\[btnfr"/\\]/ display contained
 syn match tomlEscape /\\u\x\{4}/ contained
 syn match tomlEscape /\\U\x\{8}/ contained
@@ -46,24 +52,26 @@ syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 hi def link tomlDate Constant
 
-syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]._-]+\ze\s*\=/ display
+syn match tomlKey /\v[a-z_\-]+(\.[a-z_\-]+)*(\s*\=)@=/ display
 hi def link tomlKey Identifier
 
 syn region tomlKeyDq oneline start=/\v(^|[{,])\s*\zs"/ end=/"\ze\s*=/ contains=tomlEscape
-hi def link tomlKeyDq Identifier
+hi def link tomlKeyDq tomlKey
 
 syn region tomlKeySq oneline start=/\v(^|[{,])\s*\zs'/ end=/'\ze\s*=/
-hi def link tomlKeySq Identifier
+hi def link tomlKeySq tomlKey
 
-syn region tomlTable oneline start=/^\s*\[[^\[]/ end=/\]/ contains=tomlKey,tomlKeyDq,tomlKeySq
+syn cluster tomlTableKeys contains=tomlKey,tomlKeyDq,tomlKeySq
+
+syn match tomlTable /\v(^\s*\[?\s*)@<=\[[a-z_\-]+(\.[a-z_\-]+)*\](\s*\]?\s*$)@=/ contains=@tomlKeys display
 hi def link tomlTable Title
 
-syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKey,tomlKeyDq,tomlKeySq
-hi def link tomlTableArray Title
+syn region tomlTableInline matchgroup=tomlTable start="\V{" end="\V}" contains=ALLBUT,tomlTable transparent
 
-syn cluster tomlValue contains=tomlArray,tomlString,tomlInteger,tomlFloat,tomlBoolean,tomlDate,tomlComment
-syn region tomlKeyValueArray start=/=\s*\[\zs/ end=/\]/ contains=@tomlValue
-syn region tomlArray start=/\[/ end=/\]/ contains=@tomlValue contained
+syn cluster tomlValue contains=tomlArray,tomlTableInline,tomlString,tomlInteger,tomlFloat,tomlBoolean,tomlDate,tomlComment
+
+syn match tomlArray /\v[\[\]]/ contains=tomlTable display
+hi def link tomlArray tomlNoise
 
 syn keyword tomlTodo TODO FIXME XXX BUG contained
 hi def link tomlTodo Todo


### PR DESCRIPTION
This PR adds highlighting of delimiters, and takes steps to increase the usage of those delimiters in all areas of the syntax file.

This PR also incorporates functionality provided by #52.

___

I know that the maintainer's opinion is that highlighting individual characters isn't all that useful­— although, from the perspective of a colorscheme maintainer it is the opposite:

* If you want tokens in a language to appear the same, then one may simply change those links to be the same and any potential distraction is negated. 
* If one pursues adherence to semantic highlighting, not having enough customization means that there is just nothing you can do to further define tokens for a language.

As such, as long as `display` is used where applicable and `nextgroup`/`contains` is used to meaningfully provide hints to Vim about the location of syntax groups, the benefits appear to be enough that such changes are worth inclusion.