### PR TITLE
Simplify git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ distribution.
 Clone or submodule this repo into your Vim packages location. Example:
 
 ```
-mkdir -p ~/.vim/pack/plugins/start
-cd ~/.vim/pack/plugins/start
-git clone https://github.com/cespare/vim-toml.git
+git clone https://github.com/cespare/vim-toml.git ~/.vim/pack/plugins/start/vim-toml
 ```
 
 ### Pathogen


### PR DESCRIPTION
I believe there are no unwanted side effects to combining the `git clone` and subdirectory creation commands, so I wrote a simple revision to README.md . As an advantage, users would no longer need to change directories. It takes seconds to run the command and continue working.