### PR TITLE
Recognize PDM's pdm.lock format as toml

### DIFF
--- a/ftdetect/toml.vim
+++ b/ftdetect/toml.vim
@@ -1,2 +1,2 @@
 " Go dep and Rust use several TOML config files that are not named with .toml.
-autocmd BufNewFile,BufRead *.toml,Gopkg.lock,Cargo.lock,*/.cargo/config,*/.cargo/credentials,Pipfile set filetype=toml
+autocmd BufNewFile,BufRead *.toml,pdm.lock,Gopkg.lock,Cargo.lock,*/.cargo/config,*/.cargo/credentials,Pipfile set filetype=toml


### PR DESCRIPTION
The [PDM](https://pdm.fming.dev/latest/) package manager uses toml for it's lock files.  Adding it the ftdetect.