### PR TITLE
Remove word begin (\<) and end (\>) atoms from number patterns

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -23,15 +23,15 @@ syn region tomlString oneline start=/'/ end=/'/
 " Multi-line literal strings
 syn region tomlString start=/'''/ end=/'''/
 
-syn match tomlInteger /[+-]\=\<[1-9]\(_\=\d\)*\>/ display
-syn match tomlInteger /[+-]\=\<0\>/ display
-syn match tomlInteger /[+-]\=\<0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*\>/ display
-syn match tomlInteger /[+-]\=\<0o[0-7]\(_\=[0-7]\)*\>/ display
-syn match tomlInteger /[+-]\=\<0b[01]\(_\=[01]\)*\>/ display
-syn match tomlInteger /[+-]\=\<\(inf\|nan\)\>/ display
+syn match tomlInteger /[+-]\=[1-9]\(_\=\d\)*/ display
+syn match tomlInteger /[+-]\=0/ display
+syn match tomlInteger /[+-]\=0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*/ display
+syn match tomlInteger /[+-]\=0o[0-7]\(_\=[0-7]\)*/ display
+syn match tomlInteger /[+-]\=0b[01]\(_\=[01]\)*/ display
+syn match tomlInteger /[+-]\=\(inf\|nan\)/ display
 
-syn match tomlFloat /[+-]\=\<\d\(_\=\d\)*\.\d\+\>/ display
-syn match tomlFloat /[+-]\=\<\d\(_\=\d\)*\(\.\d\(_\=\d\)*\)\=[eE][+-]\=\d\(_\=\d\)*\>/ display
+syn match tomlFloat /[+-]\=\d\(_\=\d\)*\.\d\+/ display
+syn match tomlFloat /[+-]\=\d\(_\=\d\)*\(\.\d\(_\=\d\)*\)\=[eE][+-]\=\d\(_\=\d\)*/ display
 
 syn match tomlBoolean /\<\%(true\|false\)\>/ display
 


### PR DESCRIPTION
After '-' was added to  'iskeyword' characters (see 31e3005667b), the previous number patterns stopped matching negative numbers.

For example, the string "-1", does not match the regex /[+-]\=\<[1-9]/ since now "-" already matches the beginning of the word.