### PR TITLE
Add fold regions to Tables and TableArrays

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -45,9 +45,14 @@ syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]._-]+\ze\s*\=/ contains=tomlDotInKe
 syn region tomlKeyDq oneline start=/\v(^|[{,])\s*\zs"/ end=/"\ze\s*=/ contains=tomlEscape
 syn region tomlKeySq oneline start=/\v(^|[{,])\s*\zs'/ end=/'\ze\s*=/
 
-syn region tomlTable oneline start=/^\s*\[[^\[]/ end=/\]/ contains=tomlKey,tomlKeyDq,tomlKeySq,tomlDotInKey
+" Match table and table array headers. Distinguish from inline arrays by
+" allowing commas only inside single or double quotes.
+let s:HEADER_RE = '^\s*\[\[=%(([''"])%(\1@!.|\\"){-}\1|[^,''"]{-1,}){-1,}\]\]=\s*%(#|$)'
+exe 'syn region tomlFold start=/\v' . s:HEADER_RE . '/ end=/\v%(' . s:HEADER_RE . ')@=/ fold transparent'
 
-syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKey,tomlKeyDq,tomlKeySq,tomlDotInKey
+syn region tomlTable oneline start=/^\s*\[[^\[]/ end=/\]/ contains=tomlKey,tomlKeyDq,tomlKeySq,tomlDotInKey containedin=tomlFold contained
+
+syn region tomlTableArray oneline start=/^\s*\[\[/ end=/\]\]/ contains=tomlKey,tomlKeyDq,tomlKeySq,tomlDotInKey containedin=tomlFold contained
 
 syn region tomlKeyValueArray start=/=\s*\[\zs/ end=/\]/ contains=@tomlValue
 

--- a/test/test.toml
+++ b/test/test.toml
@@ -26,6 +26,12 @@ apple.type = "fruit"
 3.14159 = "pi"
 "127.0.0.1" = "value"
 
+[foo."".'bar, actually'] # Empty string as key, key with a comma
+foldbug = [
+  ["a"] , # BUG: Remove comma to trigger folding bug
+]
+'' = "empty"
+
 [[foo.quux]]
 e = 2
 


### PR DESCRIPTION
Tables and TableArrays are folded when `foldmethod=syntax` is set.

The folds are implemented by a single regex which matches the table and table array headers. This has to replicate a large part of the syntax for TOML keys, so the regex becomes a bit involved. Fold levels are limited to 1 for a table and 0 for the part before the first table. This is because dictionary depth cannot be parsed from the header with a regex and cannot be communicated to vim by syntax statements anyway.

There is an edge case where a valid inline array looks like a table header, and is detected as such. This is hopefully rare enough in practice to not matter. A demonstration of this  is added to `test.toml`.

This perhaps could have been implemented with a clever use of `contains`, `containedin` etc., but that would require a larger refactoring and maybe fixing of other bugs such as #58.

Fixes #63.