### PR TITLE
Don't wrap text outside of comments

### DIFF
--- a/ftplugin/toml.vim
+++ b/ftplugin/toml.vim
@@ -12,10 +12,11 @@ let b:did_ftplugin = 1
 
 let s:save_cpo = &cpo
 set cpo&vim
-let b:undo_ftplugin = 'setlocal commentstring< comments< iskeyword<'
+let b:undo_ftplugin = 'setlocal commentstring< comments< formatoptions< iskeyword<'
 
 setlocal commentstring=#\ %s
 setlocal comments=:#
+setlocal formatoptions-=t
 setlocal iskeyword+=-
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Vim currently wraps lines like `long_key = "long_value"`, which breaks TOML syntax.