### PR TITLE
Correct highlight of dates

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -37,8 +37,8 @@ syn match tomlBoolean /\<\%(true\|false\)\>/ display
 
 " https://tools.ietf.org/html/rfc3339
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}/ display
-syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
-syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
+syn match tomlDate /\d\{2\}:\d\{2\}\%(:\d\{2\}\%(\.\d\+\)\?\)\?/ display
+syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[Tt ]\d\{2\}:\d\{2\}\%(:\d\{2\}\%(\.\d\+\)\?\)\?\%([Zz]\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 
 syn match tomlDotInKey /\v[^.]+\zs\./ contained display
 syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]._-]+\ze\s*\=/ contains=tomlDotInKey display


### PR DESCRIPTION
ABNF is case-insensitive, so RFC3339 and TOML allow lower-case "t" and "z".

Also wrap seconds in \%(..\)\?, since that's optional since TOML 1.1

Before:
<img width="389" height="119" alt="before" src="https://github.com/user-attachments/assets/f9c655fa-21bb-402f-8251-829fa3b830df" />


After:
<img width="361" height="109" alt="after" src="https://github.com/user-attachments/assets/58c27a26-af2f-4d35-90f4-3f462575859c" />